### PR TITLE
Fix typo in documentation: reference/instructions

### DIFF
--- a/doc/src/reference/instructions.md
+++ b/doc/src/reference/instructions.md
@@ -240,7 +240,7 @@ All opcodes are given in hexadecimal; other numbers are decimal.
 | $00+X    | 3B     | 2           | 5      | NZC       |
 | $0000    | 2C     | 3           | 5      | NZC       |
 
-## `ROL`
+## `ROR`
 
 `ROR` instructions perform (one) in-place right rotation on the operand; the shifted-around bit is stored in the carry flag.
 


### PR DESCRIPTION
`ROL` is specified twice as a second level heading, the latter instance should be `ROR`.